### PR TITLE
scudo-sys: Fix rerun-if-changed typo

### DIFF
--- a/scudo-sys/Cargo.toml
+++ b/scudo-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scudo-sys"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2018"
 license = "Apache-2.0"
 readme = "README.md"

--- a/scudo-sys/build.rs
+++ b/scudo-sys/build.rs
@@ -16,8 +16,10 @@ extern crate cc;
 use std::fs::read_dir;
 use std::path::Path;
 
+const SCUDO_RUST_WRAPPER: &str = "src/scudo_rust_wrapper.cpp";
+
 fn main() {
-    println!("cargo:rerun-if-changed=src/scudo_rust_wrapper.c");
+    println!("cargo:rerun-if-changed={}", SCUDO_RUST_WRAPPER);
     let scudo_dir = Path::new("scudo-standalone");
 
     // Get all .cpp files besides the wrappers.
@@ -34,7 +36,7 @@ fn main() {
 
     cc::Build::new()
         .files(scudo_cpp_files)
-        .file("src/scudo_rust_wrapper.cpp")
+        .file(SCUDO_RUST_WRAPPER)
         .include(scudo_dir)
         .include(scudo_dir.join("include"))
         .cpp(true)


### PR DESCRIPTION
The file specified does not exist, so cargo will re-run the build.rs file on every single build.

TEST=cargo build && cargo build
second run will use cached results.